### PR TITLE
Add receipt flag to ctc tx

### DIFF
--- a/src/ctc/cli/commands/data/tx_command.py
+++ b/src/ctc/cli/commands/data/tx_command.py
@@ -4,7 +4,6 @@ import toolcli
 
 from ctc import evm
 
-
 def get_command_spec() -> toolcli.CommandSpec:
     return {
         'f': async_transaction_command,
@@ -18,24 +17,48 @@ def get_command_spec() -> toolcli.CommandSpec:
                 'action': 'store_true',
                 'dest': 'as_json',
             },
+            {
+                'name': '--receipt',
+                'help': 'output transaction receipt (only works with --json)',
+                'action': 'store_true',
+                'dest': 'receipt',
+            },
         ],
         'examples': [
             '0xe981fe5c78d11d935a1dc35c579969e65e2dd6bb05ad321ea9670f8b1e203eaf',
+            '0xe981fe5c78d11d935a1dc35c579969e65e2dd6bb05ad321ea9670f8b1e203eaf --json',
+            '0xe981fe5c78d11d935a1dc35c579969e65e2dd6bb05ad321ea9670f8b1e203eaf --json --receipt',
         ],
     }
 
 
 async def async_transaction_command(
-    *, transaction: str, sort: str, as_json: bool
+    *, transaction: str, sort: str, as_json: bool, receipt: bool
 ) -> None:
 
     if as_json:
         import json
+        import asyncio
+        from ctc import rpc
+
+        if receipt:
+            receipt_task = asyncio.create_task(
+                rpc.async_eth_get_transaction_receipt(
+                    transaction_hash=transaction
+                )
+            )
+            receipt_data = await receipt_task
+            print(json.dumps(receipt_data, sort_keys=True, indent=4))
+            return
 
         transaction_data = await evm.async_get_transaction(transaction)
         print(json.dumps(transaction_data, sort_keys=True, indent=4))
 
     else:
+        if receipt:
+            print('receipt flag only works with --json')
+            return
+        
         await evm.async_print_transaction_summary(
             transaction_hash=transaction, sort_logs_by=sort
         )


### PR DESCRIPTION
This PR adds a `--receipt` flag to the `ctc tx` CLI command.

If this flag is provided, it outputs the transaction receipt, rather than the transaction object:

```
$ ctc tx 0xe981fe5c78d11d935a1dc35c579969e65e2dd6bb05ad321ea9670f8b1e203eaf --json --receipt
{
    "block_hash": "0x31ca8a95a453f99f903e1bce5f0cc2619a790e6c802d94e6495e30b35b44e8d3",
    "block_number": 14677571,
    "contract_address": null,
    "cumulative_gas_used": 14115255,
    "effective_gas_price": 27791304941,
    "from": "0x97d567ea6062df0b02b88092f1a5a28a9fb8b984",
    "gas_used": 199142,
    "logs": [
        {
            "address": "0xfd3300a9a74b3250f1b2abc12b47611171910b07",
            "blockHash": "0x31ca8a95a453f99f903e1bce5f0cc2619a790e6c802d94e6495e30b35b44e8d3",
            "blockNumber": "0xdff643",
            "data": "0x000000000000000000000000000000000000000000a69606d83098d8eea7e60800000000000000000000000000000000000000000000000000093f16d65b5b8a0000000000000000000000000000000000000000000000000ecaae6d5916c235000000000000000000000000000000000000000000005c6663dd81bf07a1f2d9",
            "logIndex": "0xe1",
            "removed": false,
            "topics": [
                "0x4dec04e750ca11537cabcd8a9eab06494de08da3735bc8871cd41250e190bc04"
            ],
            "transactionHash": "0xe981fe5c78d11d935a1dc35c579969e65e2dd6bb05ad321ea9670f8b1e203eaf",
            "transactionIndex": "0xef"
        },
        {
            "address": "0x73f16f0c0cd1a078a54894974c5c054d8dc1a3d7",
            "blockHash": "0x31ca8a95a453f99f903e1bce5f0cc2619a790e6c802d94e6495e30b35b44e8d3",
            "blockNumber": "0xdff643",
            "data": "0x000000000000000000000000000000000000000000000000000000000006ff040000000000000000000000000000000000de2c022f2d4d10de7946e3b1bed459",
            "logIndex": "0xe2",
            "removed": false,
            "topics": [
                "0x2caecd17d02f56fa897705dcc740da2d237c373f70686f4e0d9bd3bf0400ea7a",
                "0x000000000000000000000000fd3300a9a74b3250f1b2abc12b47611171910b07",
                "0x00000000000000000000000097d567ea6062df0b02b88092f1a5a28a9fb8b984"
            ],
            "transactionHash": "0xe981fe5c78d11d935a1dc35c579969e65e2dd6bb05ad321ea9670f8b1e203eaf",
            "transactionIndex": "0xef"
        },
        {
            "address": "0xc7283b66eb1eb5fb86327f08e1b5816b0720212b",
            "blockHash": "0x31ca8a95a453f99f903e1bce5f0cc2619a790e6c802d94e6495e30b35b44e8d3",
            "blockNumber": "0xdff643",
            "data": "0x0000000000000000000000000000000000000000000034f086f3bb1797a131cc",
            "logIndex": "0xe3",
            "removed": false,
            "topics": [
                "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
                "0x00000000000000000000000097d567ea6062df0b02b88092f1a5a28a9fb8b984",
                "0x000000000000000000000000fd3300a9a74b3250f1b2abc12b47611171910b07"
            ],
            "transactionHash": "0xe981fe5c78d11d935a1dc35c579969e65e2dd6bb05ad321ea9670f8b1e203eaf",
            "transactionIndex": "0xef"
        },
        {
            "address": "0xfd3300a9a74b3250f1b2abc12b47611171910b07",
            "blockHash": "0x31ca8a95a453f99f903e1bce5f0cc2619a790e6c802d94e6495e30b35b44e8d3",
            "blockNumber": "0xdff643",
            "data": "0x00000000000000000000000097d567ea6062df0b02b88092f1a5a28a9fb8b9840000000000000000000000000000000000000000000034f086f3bb1797a131cc0000000000000000000000000000000000000000000033be7096837b0b003f33",
            "logIndex": "0xe4",
            "removed": false,
            "topics": [
                "0x4c209b5fc8ad50758f13e2e1088ba56a560dff690a1c6fef26394f4c03821c4f"
            ],
            "transactionHash": "0xe981fe5c78d11d935a1dc35c579969e65e2dd6bb05ad321ea9670f8b1e203eaf",
            "transactionIndex": "0xef"
        },
        {
            "address": "0xfd3300a9a74b3250f1b2abc12b47611171910b07",
            "blockHash": "0x31ca8a95a453f99f903e1bce5f0cc2619a790e6c802d94e6495e30b35b44e8d3",
            "blockNumber": "0xdff643",
            "data": "0x0000000000000000000000000000000000000000000033be7096837b0b003f33",
            "logIndex": "0xe5",
            "removed": false,
            "topics": [
                "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
                "0x000000000000000000000000fd3300a9a74b3250f1b2abc12b47611171910b07",
                "0x00000000000000000000000097d567ea6062df0b02b88092f1a5a28a9fb8b984"
            ],
            "transactionHash": "0xe981fe5c78d11d935a1dc35c579969e65e2dd6bb05ad321ea9670f8b1e203eaf",
            "transactionIndex": "0xef"
        }
    ],
    "logs_bloom": "0x00000000000000000000000000000000000000000000400000000000000001100000000000000000000000000000000000000000000000000000004000000000000000000000000000000008080000000000000000000004000410000000000000000000000000000000000000000000000000000008000000000010000000000000000000001000000000000000000000000000200020200000004400000080000000040000000000000000000000000000000000000000000000000000000000000002000000000004000000020000000000000000000000000000000020000000000000000200000020000040000000200000000000000000000000000000",
    "status": 1,
    "to": "0xfd3300a9a74b3250f1b2abc12b47611171910b07",
    "transaction_hash": "0xe981fe5c78d11d935a1dc35c579969e65e2dd6bb05ad321ea9670f8b1e203eaf",
    "transaction_index": 239,
    "type": "0x2"
}
```

Since the plain text output provides this information already, this flag only works when supplied with `--json`.
