### PR TITLE
Add deployed at block number to ctc address for contracts

### DIFF
--- a/src/ctc/evm/address_utils/address_summary.py
+++ b/src/ctc/evm/address_utils/address_summary.py
@@ -57,9 +57,18 @@ async def async_print_address_summary(
     rows = [
         ('checksum', toolstr.add_style(address_data.get_address_checksum(address), styles['metavar'])),
         ('address type', address_type),
-        ('ETH balance', eth_balance),
-        ('transaction count', transaction_count),
     ]
+
+    if is_contract:
+        deploy_block_coroutine = evm.async_address_deployed_at_block(
+            address, provider=provider
+        )
+        deploy_block = await deploy_block_coroutine
+        rows.append(('deployed at block', toolstr.add_style(str(deploy_block), styles['metavar'])))
+    
+    rows.append(('transaction count', transaction_count))
+    rows.append(('ETH balance', eth_balance))
+        
     print()
     toolstr.print_table(
         rows,


### PR DESCRIPTION
This PR finds the block at which a contract address was deployed, by performing a binary search between the latest block and the first block number. The moment that the contract returns a non-zero value for get_code, we consider it to be deployed.

An example:

```
$ ctc address 0xbebc44782c7db0a1a60cb6fe97d0b483032ff1c7
┌────────────────────────────────────────────────────┐
│ Address 0xbebc44782c7db0a1a60cb6fe97d0b483032ff1c7 │
└────────────────────────────────────────────────────┘

           checksum  │  0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7
       address type  │  contract
  deployed at block  │  10809473
  transaction count  │  1
        ETH balance  │  0

...
```

If the user supplies an EOA, no extra work will be done.

This PR is incomplete in two important respects:

* I'm not sure where to put tests. There don't seem to be direct tests for the address_queries file
* The deployed at block number is the sort of thing that can, and should, be cached. Right now the search is performed on each run.